### PR TITLE
Get rid off the 'overview' node and let the API determine if the node should have content

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -26,7 +26,7 @@
 				</div>
 			</template>
 
-			<v-list class="on-primary bg-primary">
+			<v-list density="compact" class="on-primary bg-primary">
 				<v-list-item
 					title="Home"
 					:to="{name: 'home'}"

--- a/src/components/NavTreeNode.vue
+++ b/src/components/NavTreeNode.vue
@@ -1,69 +1,116 @@
 <template>
-  <v-list-item
-      v-if="sortedChildren === null"
-      :title="displayName"
-      :to="link"
-      :active="active"
-  />
-  <v-list-group v-else>
-    <template #activator="{ props }">
-      <v-list-item
-          v-bind="props"
-          :title="displayName"
-      />
-    </template>
+	<v-list-item
+		v-if="sortedChildren === null"
+		:title="displayName"
+		:to="link"
+		:active="active"
+	/>
+	<v-list-group v-else>
+		<template #activator="{ props }">
+			<v-list-item
+				:title="displayName"
+				:active="active"
+				style="flex-grow: 1"
+				@click="onClick(props.active, props.onClick)"
+			>
+				<v-btn
+					@click.stop="onExpand(props.active, props.onClick)"
+					:active="props.active"
+					:icon="props.appendIcon"
+					:color="props.color"
+					:class="props.class"
+					:flat="true"
+					density="compact"
+				/>
+			</v-list-item>
+		</template>
 
-    <v-list-item
-        title="Overview"
-        :to="link"
-        :active="active"
-    />
-
-    <nav-tree-node v-for="(childNode, i) of sortedChildren" :node="childNode" :key="i"/>
-  </v-list-group>
+		<nav-tree-node v-for="(childNode, i) of sortedChildren" :node="childNode" :key="i"/>
+	</v-list-group>
 </template>
 
 <script lang="ts">
 import {defineComponent} from 'vue'
 
 export default defineComponent({
-  name: "NavTreeNode",
+	name: "NavTreeNode",
 
-  props: {
-    node: {
-      type: Object,
-      required: true,
-      validator: (n: unknown): boolean => {
-        return Object.hasOwnProperty.call(n, 'nodeName') &&
-            Object.hasOwnProperty.call(n, 'location') &&
-            Object.hasOwnProperty.call(n, 'order');
-      },
-    },
-  },
+	props: {
+		node: {
+			type: Object,
+			required: true,
+			validator: (n: unknown): boolean => {
+				return Object.hasOwnProperty.call(n, 'nodeName') &&
+					Object.hasOwnProperty.call(n, 'location') &&
+					Object.hasOwnProperty.call(n, 'order');
+			},
+		},
+	},
 
-  computed: {
-    sortedChildren() {
-      if (typeof this.node.children === 'undefined') {
-        return null;
-      }
+	data() {
+		return {
+			expanded: false,
+		}
+	},
 
-      // do not sort node.children directly, because it would modify the original array
-      return [...Object.keys(this.node.children).map(k => this.node.children[k]).filter(n => n.order >= 0)].sort((a, b) => {
-        return a.order - b.order;
-      });
-    },
+	methods: {
+		onClick(expanded: boolean, cb: () => void) {
+			let toggle = false
+			let navigate = false
 
-    displayName() {
-      return this.node.nodeName;
-    },
+			if (expanded && this.active) {
+				toggle = true
+				this.expanded = false
+			} else if (expanded && !this.active) {
+				navigate = true
+			} else if (!expanded && this.active) {
+				toggle = true
+				this.expanded = true
+			} else {
+				navigate = true
+				toggle = true
+				this.expanded = true
+			}
 
-    link() {
-      return '/wiki/' + this.node.location;
-    },
+			if (toggle) {
+				cb()
+			}
 
-    active() {
-      return this.$route.params.location === this.node.location;
-    },
-  },
+			if (navigate) {
+				// TODO: also check if this node contains content and only then navigate to it
+				this.$router.push(this.link)
+			}
+		},
+
+		onExpand(expanded: boolean, cb: () => void) {
+			this.expanded = !expanded
+			cb()
+		}
+	},
+
+	computed: {
+		sortedChildren() {
+			if (typeof this.node.children === 'undefined') {
+				return null;
+			}
+
+			// do not sort node.children directly, because it would modify the original array
+			return [...Object.keys(this.node.children).map(k => this.node.children[k]).filter(n => n.order >= 0)].sort((a, b) => {
+				return a.order - b.order;
+			});
+		},
+
+		displayName() {
+			return this.node.nodeName;
+		},
+
+		link() {
+			return '/wiki/' + this.node.location;
+		},
+
+		active() {
+			return this.$route.params.location === this.node.location;
+		},
+	},
 })
 </script>

--- a/src/components/NavTreeNode.vue
+++ b/src/components/NavTreeNode.vue
@@ -15,9 +15,8 @@
 			>
 				<v-btn
 					@click.stop="onExpand(props.active, props.onClick)"
-					:active="props.active"
 					:icon="props.appendIcon"
-					:color="props.color"
+					color="transparent"
 					:class="props.class"
 					:flat="true"
 					density="compact"

--- a/src/components/NavTreeNode.vue
+++ b/src/components/NavTreeNode.vue
@@ -39,11 +39,11 @@ export default defineComponent({
 		node: {
 			type: Object,
 			required: true,
-			validator: (n: unknown): boolean => {
-				return Object.hasOwnProperty.call(n, 'nodeName') &&
-					Object.hasOwnProperty.call(n, 'location') &&
-					Object.hasOwnProperty.call(n, 'order');
-			},
+			validator: (n: unknown): boolean =>
+				Object.hasOwnProperty.call(n, 'nodeName') &&
+				Object.hasOwnProperty.call(n, 'location') &&
+				Object.hasOwnProperty.call(n, 'hasContent') &&
+				Object.hasOwnProperty.call(n, 'order'),
 		},
 	},
 
@@ -58,12 +58,14 @@ export default defineComponent({
 			let toggle = false
 			let navigate = false
 
-			if (expanded && this.active) {
+			const active = this.active || !this.node.hasContent;
+
+			if (expanded && active) {
 				toggle = true
 				this.expanded = false
-			} else if (expanded && !this.active) {
+			} else if (expanded && !active) {
 				navigate = true
-			} else if (!expanded && this.active) {
+			} else if (!expanded && active) {
 				toggle = true
 				this.expanded = true
 			} else {
@@ -76,8 +78,7 @@ export default defineComponent({
 				cb()
 			}
 
-			if (navigate) {
-				// TODO: also check if this node contains content and only then navigate to it
+			if (this.node.hasContent && navigate) {
 				this.$router.push(this.link)
 			}
 		},

--- a/src/models/NavNode.ts
+++ b/src/models/NavNode.ts
@@ -5,5 +5,6 @@ export interface NavNode {
     order: number;
     location: string;
     nodeName: string;
+    hasContent: boolean;
     children?: NavTree;
 }


### PR DESCRIPTION
This implements the logic described in https://github.com/trenz-gmbh/trenz-docs/issues/4#issuecomment-1195699807.

If you click on a node which has the `hasContent` flag set, you see the content view for this node and additionally, if the node has children, the children are expanded.

This also requires trenz-gmbh/trenz-docs-api#6 to be merged.
This fixes #4.