### PR TITLE
Add some styling to blockquotes

### DIFF
--- a/src/components/MarkdownContent.vue
+++ b/src/components/MarkdownContent.vue
@@ -148,6 +148,12 @@ details.table-of-contents {
     }
   }
 }
+
+blockquote {
+  padding-left: 0.5rem;
+  border-left: solid 0.25rem rgba(var(--v-border-color), var(--v-border-opacity));
+  color: rgba(var(--v-border-color), 0.6);
+}
 </style>
 
 <script lang="ts">


### PR DESCRIPTION
![image](https://github.com/trenz-gmbh/trenz-docs/assets/6266356/45407542-034a-46dd-8e41-fa2c02b49113)

This should fix #60, although we might extend this to support icons like GHFM for example.